### PR TITLE
Dropping the setup of demo from the postinstall hook.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clobber": "rm -rf elm-stuff demo/elm-stuff demo/.webpack tests/elm-stuff tests/Doc",
     "rebuild": "npm run clobber && npm install && npm test",
     "deploy:demo": "cd demo && cross-env NODE_ENV=production serverless deploy",
-    "postinstall": "elm package install -y && cd demo && elm package install -y",
+    "postinstall": "elm package install -y",
     "posttest": "eslint .",
     "pretest": "node scripts/test-server",
     "start": "cd demo && serverless offline",


### PR DESCRIPTION
I am testing the `master` branch of the upcoming `4.0.0` release. I have added this to my `devDependencies`:
```
"elm-serverless": "https://github.com/ktonon/elm-serverless.git#0e1a153484da9854a2a709a469e91253c0a1c5de",
```
But when running `npm install`, I get this error:
```
sh: line 0: cd: demo: No such file or directory
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! elm-serverless@3.0.2 postinstall: `elm package install -y && cd demo && elm package install -y`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the elm-serverless@3.0.2 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
The output above displays `3.0.2` because that is still the version in `package.json`, while it is already `4.0.0` in `elm-package.json`.

As a separate repo, your demo setup works. But when using `elm-serverless` as a dependency in my own project, it's not. To prevent my `npm install` of failing, I dropped the setup of `demo` from the `postinstall` hook.
