### PR TITLE
Add binary support

### DIFF
--- a/demo/src/Config/API.elm
+++ b/demo/src/Config/API.elm
@@ -1,4 +1,4 @@
-port module Config.API exposing (..)
+port module Config.API exposing (Auth, Config, Protocol(..), Service, configDecoder, main, protocolDecoder, requestPort, responsePort, resultToDecoder, serviceDecoder)
 
 import Json.Decode exposing (Decoder, andThen, fail, int, map, string, succeed)
 import Json.Decode.Pipeline exposing (decode, required)

--- a/demo/src/Interop/API.elm
+++ b/demo/src/Interop/API.elm
@@ -1,4 +1,4 @@
-port module Interop.API exposing (..)
+port module Interop.API exposing (Conn, Interop(..), Msg(..), Route(..), encodeInterop, endpoint, interopDecoder, main, requestPort, responsePort, update)
 
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode

--- a/demo/src/Quoted/API.elm
+++ b/demo/src/Quoted/API.elm
@@ -1,4 +1,4 @@
-module Quoted.API exposing (..)
+module Quoted.API exposing (main, pipeline, router, update)
 
 import Json.Encode
 import Quoted.Middleware

--- a/demo/src/Quoted/Models/Quote.elm
+++ b/demo/src/Quoted/Models/Quote.elm
@@ -1,10 +1,11 @@
-module Quoted.Models.Quote exposing (..)
+module Quoted.Models.Quote exposing (decoder, encodeList, format, request)
 
 import Http
 import Json.Decode exposing (Decoder, string)
 import Json.Decode.Pipeline exposing (decode, hardcoded, required)
 import Json.Encode as J
 import Quoted.Types exposing (Quote)
+
 
 
 -- MODEL

--- a/demo/src/Quoted/Pipelines/Quote.elm
+++ b/demo/src/Quoted/Pipelines/Quote.elm
@@ -1,4 +1,4 @@
-module Quoted.Pipelines.Quote exposing (..)
+module Quoted.Pipelines.Quote exposing (gotQuotes, langFilter, loadQuotes, router)
 
 import Http
 import Quoted.Models.Quote as Quote
@@ -82,5 +82,6 @@ langFilter filt langs =
         Lang string ->
             if langs |> List.member string then
                 [ string ]
+
             else
                 []

--- a/demo/src/Quoted/Route.elm
+++ b/demo/src/Quoted/Route.elm
@@ -1,4 +1,4 @@
-module Quoted.Route exposing (..)
+module Quoted.Route exposing (Lang(..), Query, Route(..), Sort(..), lang, query, route, sort)
 
 import UrlParser exposing (..)
 
@@ -59,6 +59,7 @@ sort =
         >> (\val ->
                 if val == "asc" then
                     Asc
+
                 else
                     Desc
            )

--- a/demo/src/Quoted/Types.elm
+++ b/demo/src/Quoted/Types.elm
@@ -1,4 +1,4 @@
-port module Quoted.Types exposing (..)
+port module Quoted.Types exposing (Config, Conn, Interop(..), Msg(..), Plug, Quote, configDecoder, interopDecoder, interopEncode, requestPort, responsePort)
 
 import Http
 import Json.Decode as Decode exposing (Decoder)
@@ -8,6 +8,7 @@ import Quoted.Route exposing (Route)
 import Serverless
 import Serverless.Conn exposing (Id)
 import Serverless.Plug
+
 
 
 -- CUSTOM TYPES

--- a/demo/src/Routing/API.elm
+++ b/demo/src/Routing/API.elm
@@ -1,4 +1,4 @@
-port module Routing.API exposing (..)
+port module Routing.API exposing (Conn, Route(..), main, requestPort, responsePort, router)
 
 import Serverless
 import Serverless.Conn exposing (method, respond, route, textBody)

--- a/demo/src/SideEffects/API.elm
+++ b/demo/src/SideEffects/API.elm
@@ -1,4 +1,4 @@
-port module SideEffects.API exposing (..)
+port module SideEffects.API exposing (Conn, Msg(..), Route(..), endpoint, main, requestPort, responsePort, update)
 
 import Json.Encode
 import Random

--- a/src-bridge/response-handler.js
+++ b/src-bridge/response-handler.js
@@ -28,12 +28,14 @@ const handler = ({ pool, logger = defaultLogger }) => function responseHandler(i
         statusCode: 500,
         body: `${missingStatusCodeBody}: ${resp.statusCode}`,
         headers: defaultHeaders(''),
+        isBase64Encoded: !!resp.isBase64Encoded
       });
     } else {
       callback(null, {
         statusCode,
         body: encodeBody(resp.body, statusCode),
         headers: resp.headers || defaultHeaders(resp.body),
+        isBase64Encoded: !!resp.isBase64Encoded
       });
     }
   } else {

--- a/src/Logging.elm
+++ b/src/Logging.elm
@@ -1,4 +1,4 @@
-module Logging exposing (..)
+module Logging exposing (LogLevel(..), Logger, defaultLogger, logLevelToInt, logger, nullLogger)
 
 {-| Available Log levels
 -}
@@ -44,6 +44,7 @@ logger : LogLevel -> Logger a
 logger minLevel level label val =
     if (minLevel |> logLevelToInt) > (level |> logLevelToInt) then
         Debug.log ((level |> toString) ++ ": " ++ label) val
+
     else
         val
 

--- a/src/Serverless.elm
+++ b/src/Serverless.elm
@@ -1,16 +1,9 @@
-module Serverless
-    exposing
-        ( HttpApi
-        , Interop
-        , Program
-        , RequestPort
-        , ResponsePort
-        , httpApi
-        , noConfig
-        , noInterop
-        , noRoutes
-        , noSideEffects
-        )
+module Serverless exposing
+    ( httpApi, HttpApi, Program
+    , RequestPort, ResponsePort
+    , Interop
+    , noConfig, noInterop, noRoutes, noSideEffects
+    )
 
 {-| Use `httpApi` to define a `Program` that responds to HTTP requests. Take a look
 at the [demos](https://github.com/ktonon/elm-serverless/blob/master/demo)
@@ -356,6 +349,7 @@ update_ api rawMsg model =
                 errMsg =
                     if secret then
                         "Internal Server Error. Check logs for details."
+
                     else
                         err
             in

--- a/src/Serverless/Conn.elm
+++ b/src/Serverless/Conn.elm
@@ -3,7 +3,7 @@ module Serverless.Conn exposing
     , config, model, updateModel
     , request, id, method, header, route
     , respond, updateResponse, send, toSent, unsent, mapUnsent
-    , textBody, jsonBody
+    , textBody, jsonBody, binaryBody
     , interop
     , init, jsonEncodedResponse, interopCalls, interopClear
     )
@@ -47,7 +47,7 @@ Update the response and send it.
 
 Use these constructors to create response bodies with different content types.
 
-@docs textBody, jsonBody
+@docs textBody, jsonBody, binaryBody
 
 
 ## JavaScript Interop
@@ -296,6 +296,13 @@ textBody =
 jsonBody : Json.Encode.Value -> Body
 jsonBody =
     Body.json
+
+
+{-| A binary file.
+-}
+binaryBody : String -> String -> Body
+binaryBody =
+    Body.binary
 
 
 

--- a/src/Serverless/Conn.elm
+++ b/src/Serverless/Conn.elm
@@ -1,29 +1,12 @@
-module Serverless.Conn
-    exposing
-        ( Conn
-        , Id
-        , config
-        , header
-        , id
-        , init
-        , interop
-        , interopCalls
-        , interopClear
-        , jsonBody
-        , jsonEncodedResponse
-        , mapUnsent
-        , method
-        , model
-        , request
-        , respond
-        , route
-        , send
-        , textBody
-        , toSent
-        , unsent
-        , updateModel
-        , updateResponse
-        )
+module Serverless.Conn exposing
+    ( Conn, Id
+    , config, model, updateModel
+    , request, id, method, header, route
+    , respond, updateResponse, send, toSent, unsent, mapUnsent
+    , textBody, jsonBody
+    , interop
+    , init, jsonEncodedResponse, interopCalls, interopClear
+    )
 
 {-| Functions for querying and updating connections.
 

--- a/src/Serverless/Conn/Body.elm
+++ b/src/Serverless/Conn/Body.elm
@@ -3,10 +3,12 @@ module Serverless.Conn.Body exposing
     , appendText
     , asJson
     , asText
+    , binary
     , contentType
     , decoder
     , empty
     , encode
+    , isBase64Encoded
     , isEmpty
     , json
     , text
@@ -21,6 +23,7 @@ type Body
     | Error String
     | Text String
     | Json Encode.Value
+    | Binary String String
 
 
 
@@ -42,6 +45,11 @@ json =
     Json
 
 
+binary : String -> String -> Body
+binary =
+    Binary
+
+
 
 -- DESTRUCTURING
 
@@ -61,6 +69,9 @@ asText body =
         Json val ->
             Ok <| Encode.encode 0 val
 
+        Binary _ val ->
+            Ok val
+
 
 asJson : Body -> Result String Encode.Value
 asJson body =
@@ -76,6 +87,9 @@ asJson body =
 
         Json val ->
             Ok val
+
+        Binary _ val ->
+            Decode.decodeString Decode.value val
 
 
 
@@ -99,6 +113,9 @@ contentType body =
         Json _ ->
             "application/json"
 
+        Binary contentType _ ->
+            contentType
+
         _ ->
             "text/text"
 
@@ -121,6 +138,16 @@ isEmpty : Body -> Bool
 isEmpty body =
     case body of
         Empty ->
+            True
+
+        _ ->
+            False
+
+
+isBase64Encoded : Body -> Bool
+isBase64Encoded body =
+    case body of
+        Binary _ _ ->
             True
 
         _ ->
@@ -159,6 +186,9 @@ appendText val body =
 
         Json jval ->
             Err "cannot append text to json"
+
+        Binary _ _ ->
+            Err "cannot append text to binary"
 
 
 
@@ -203,3 +233,6 @@ encode body =
 
         Json j ->
             j
+
+        Binary _ v ->
+            Encode.string v

--- a/src/Serverless/Conn/Body.elm
+++ b/src/Serverless/Conn/Body.elm
@@ -1,17 +1,16 @@
-module Serverless.Conn.Body
-    exposing
-        ( Body
-        , appendText
-        , asJson
-        , asText
-        , contentType
-        , decoder
-        , empty
-        , encode
-        , isEmpty
-        , json
-        , text
-        )
+module Serverless.Conn.Body exposing
+    ( Body
+    , appendText
+    , asJson
+    , asText
+    , contentType
+    , decoder
+    , empty
+    , encode
+    , isEmpty
+    , json
+    , text
+    )
 
 import Json.Decode as Decode exposing (Decoder, andThen)
 import Json.Encode as Encode
@@ -181,6 +180,7 @@ decoder maybeType =
                                 Err err ->
                                     Decode.succeed <|
                                         Error err
+
                         else
                             Decode.succeed <| Text w
 

--- a/src/Serverless/Conn/Charset.elm
+++ b/src/Serverless/Conn/Charset.elm
@@ -1,10 +1,8 @@
-module Serverless.Conn.Charset
-    exposing
-        ( Charset
-        , default
-        , toString
-        , utf8
-        )
+module Serverless.Conn.Charset exposing
+    ( Charset
+    , default, utf8
+    , toString
+    )
 
 {-| A character encoding.
 

--- a/src/Serverless/Conn/IpAddress.elm
+++ b/src/Serverless/Conn/IpAddress.elm
@@ -1,10 +1,8 @@
-module Serverless.Conn.IpAddress
-    exposing
-        ( IpAddress
-        , decoder
-        , ip4
-        , loopback
-        )
+module Serverless.Conn.IpAddress exposing
+    ( IpAddress
+    , ip4, loopback
+    , decoder
+    )
 
 {-| Internet protocol addresses and related functions.
 
@@ -85,6 +83,7 @@ toNonNegativeInt val =
         Ok i ->
             if i >= 0 then
                 Just i
+
             else
                 Nothing
 
@@ -98,6 +97,7 @@ require4 maybeList =
         Just list ->
             if List.length list == 4 then
                 Just list
+
             else
                 Nothing
 

--- a/src/Serverless/Conn/Pool.elm
+++ b/src/Serverless/Conn/Pool.elm
@@ -1,12 +1,11 @@
-module Serverless.Conn.Pool
-    exposing
-        ( Pool
-        , empty
-        , get
-        , remove
-        , replace
-        , size
-        )
+module Serverless.Conn.Pool exposing
+    ( Pool
+    , empty
+    , get
+    , remove
+    , replace
+    , size
+    )
 
 import Dict exposing (Dict)
 import Serverless.Conn as Conn exposing (Conn, Id)

--- a/src/Serverless/Conn/Request.elm
+++ b/src/Serverless/Conn/Request.elm
@@ -1,23 +1,10 @@
-module Serverless.Conn.Request
-    exposing
-        ( Method(..)
-        , Request
-        , Scheme(..)
-        , asJson
-        , asText
-        , body
-        , decoder
-        , endpoint
-        , header
-        , init
-        , method
-        , methodDecoder
-        , path
-        , query
-        , queryString
-        , schemeDecoder
-        , stage
-        )
+module Serverless.Conn.Request exposing
+    ( Request, Method(..), Scheme(..)
+    , method, path, queryString
+    , body, asText, asJson
+    , header, query, endpoint, stage
+    , init, decoder, methodDecoder, schemeDecoder
+    )
 
 {-| Query attributes of the HTTP request.
 

--- a/src/Serverless/Conn/Response.elm
+++ b/src/Serverless/Conn/Response.elm
@@ -1,14 +1,8 @@
-module Serverless.Conn.Response
-    exposing
-        ( Response
-        , Status
-        , addHeader
-        , encode
-        , init
-        , setBody
-        , setStatus
-        , updateBody
-        )
+module Serverless.Conn.Response exposing
+    ( Response, Status
+    , addHeader, setBody, updateBody, setStatus
+    , init, encode
+    )
 
 {-| Query and update the HTTP response.
 

--- a/src/Serverless/Conn/Response.elm
+++ b/src/Serverless/Conn/Response.elm
@@ -125,6 +125,7 @@ encode (Response res) =
                 |> KeyValueList.encode
           )
         , ( "statusCode", Encode.int res.status )
+        , ( "isBase64Encoded", res.body |> Body.isBase64Encoded |> Encode.bool )
         ]
 
 

--- a/src/Serverless/Plug.elm
+++ b/src/Serverless/Plug.elm
@@ -1,12 +1,9 @@
-module Serverless.Plug
-    exposing
-        ( Plug
-        , apply
-        , nest
-        , pipeline
-        , plug
-        , size
-        )
+module Serverless.Plug exposing
+    ( Plug
+    , pipeline, plug, nest
+    , apply
+    , size
+    )
 
 {-| A **pipeline** is a sequence of functions which transform the connection,
 optionally sending back an HTTP response at each step. We use the term **plug**

--- a/test/bridge/response-handler-spec.js
+++ b/test/bridge/response-handler-spec.js
@@ -69,7 +69,7 @@ describe('responseHandler({ pool })', () => {
     }).should.be.true();
   });
 
-  it('JSON strinfies bodies which are objects', () => {
+  it('JSON stringifies bodies which are objects', () => {
     const h = makeHandler();
     const cb = sinon.spy();
     h.pool.put(id, {}, cb);
@@ -82,7 +82,7 @@ describe('responseHandler({ pool })', () => {
     }).should.be.true();
   });
 
-  it('Uses plain text for numbers', () => {
+  it('uses plain text for numbers', () => {
     const h = makeHandler();
     const cb = sinon.spy();
     h.pool.put(id, {}, cb);

--- a/test/bridge/response-handler-spec.js
+++ b/test/bridge/response-handler-spec.js
@@ -52,6 +52,7 @@ describe('responseHandler({ pool })', () => {
       statusCode: 500,
       body: `${responseHandler.missingStatusCodeBody}: undefined`,
       headers: responseHandler.defaultHeaders(''),
+      isBase64Encoded: false
     }).should.be.true();
   });
 
@@ -64,6 +65,7 @@ describe('responseHandler({ pool })', () => {
       statusCode: 404,
       body: 'not found',
       headers: responseHandler.defaultHeaders(''),
+      isBase64Encoded: false
     }).should.be.true();
   });
 
@@ -76,6 +78,7 @@ describe('responseHandler({ pool })', () => {
       statusCode: 200,
       body: '{"great":"job"}',
       headers: responseHandler.defaultHeaders({}),
+      isBase64Encoded: false
     }).should.be.true();
   });
 
@@ -88,6 +91,20 @@ describe('responseHandler({ pool })', () => {
       statusCode: 200,
       body: '42',
       headers: responseHandler.defaultHeaders(''),
+      isBase64Encoded: false
+    }).should.be.true();
+  });
+
+  it('sets isBase64Encoded to true', () => {
+    const h = makeHandler();
+    const cb = sinon.spy();
+    h.pool.put(id, {}, cb);
+    h(id, { statusCode: '200', body: 42, isBase64Encoded: true });
+    cb.calledWith(null, {
+      statusCode: 200,
+      body: '42',
+      headers: responseHandler.defaultHeaders(''),
+      isBase64Encoded: true
     }).should.be.true();
   });
 });

--- a/tests/Serverless/Conn/Fuzz.elm
+++ b/tests/Serverless/Conn/Fuzz.elm
@@ -1,11 +1,10 @@
-module Serverless.Conn.Fuzz
-    exposing
-        ( body
-        , conn
-        , header
-        , request
-        , status
-        )
+module Serverless.Conn.Fuzz exposing
+    ( body
+    , conn
+    , header
+    , request
+    , status
+    )
 
 import Fuzz exposing (Fuzzer, andMap, andThen, constant, map)
 import Fuzz.Extra exposing (eitherOr)

--- a/tests/Serverless/ConnTests.elm
+++ b/tests/Serverless/ConnTests.elm
@@ -14,7 +14,7 @@ import Serverless.Conn as Conn
         , unsent
         , updateResponse
         )
-import Serverless.Conn.Body exposing (text)
+import Serverless.Conn.Body exposing (binary, text)
 import Serverless.Conn.Fuzz as Fuzz
 import Serverless.Conn.Response as Response exposing (addHeader, setBody, setStatus)
 import Serverless.Conn.Test as Test
@@ -109,4 +109,18 @@ responseTests =
                     |> Conn.jsonEncodedResponse
                     |> Json.Encode.encode 0
                     |> Expect.match (stringPattern ("\"" ++ key ++ "\":\"" ++ value ++ "\""))
+        , Test.conn "binary sets the response header" <|
+            \conn ->
+                conn
+                    |> updateResponse (setBody <| binary "application/octet-stream" "hello")
+                    |> Conn.jsonEncodedResponse
+                    |> Json.Encode.encode 0
+                    |> Expect.match (stringPattern "\"content-type\":\"application/octet-stream; charset=utf-8\"")
+        , Test.conn "binary sets isBase64Encoded to true" <|
+            \conn ->
+                conn
+                    |> updateResponse (setBody <| binary "application/octet-stream" "hello")
+                    |> Conn.jsonEncodedResponse
+                    |> Json.Encode.encode 0
+                    |> Expect.match (stringPattern "\"isBase64Encoded\":true")
         ]

--- a/tests/Serverless/ConnTests.elm
+++ b/tests/Serverless/ConnTests.elm
@@ -1,9 +1,8 @@
-module Serverless.ConnTests
-    exposing
-        ( all
-        , buildingPipelinesTests
-        , responseTests
-        )
+module Serverless.ConnTests exposing
+    ( all
+    , buildingPipelinesTests
+    , responseTests
+    )
 
 import Expect
 import Expect.Extra as Expect exposing (stringPattern)

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -1,4 +1,4 @@
-module TestHelpers exposing (..)
+module TestHelpers exposing (Config, Conn, Interop, Model, Msg(..), Plug, Route(..), appendToBody, conn, getHeader, httpGet, requestPort, responsePort, route, simpleLoop, simplePlug)
 
 import Json.Encode as Encode
 import Regex exposing (HowMany(..), regex)


### PR DESCRIPTION
This PR adds binary support via the `isBase64Encoded` flag.
It also fixes a few typos and formats the Elm code with elm-format-0.19, however I can split these into their own PRs if desired.